### PR TITLE
feat: add option usePath to allow using host path in api

### DIFF
--- a/src/streamApiServiceProvider.js
+++ b/src/streamApiServiceProvider.js
@@ -55,7 +55,11 @@ function streamApiServiceFactory($http, $httpParamSerializer, $q) {
         }
         
         var parsedUrl = new Url(config.host);
-        config.host = parsedUrl.protocol + '//' + parsedUrl.host;
+        if (config.usePath) {
+            config.host = parsedUrl.protocol + '//' + parsedUrl.host + parsedUrl.pathname;
+        } else {
+            config.host = parsedUrl.protocol + '//' + parsedUrl.host;            
+        }
         
         if(requestNewInstance) {
             return new Api(config);


### PR DESCRIPTION
Added an option in config object that when set to `usePath: true` will append the full path to the hostname to use as the Redrock endpoint.